### PR TITLE
Upgrade to isort v5 (fixes #8)

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -20,7 +20,9 @@ dbimport() {
 runtests() {
     find /opt/enhydris* -prune -name '*.py' -o -type d | xargs black --check --diff || return
     find /opt/enhydris* -prune -name '*.py' -o -type d | xargs flake8 --max-line-length=88 || return
-    find /opt/enhydris* -prune -name '*.py' -o -type d | xargs isort --recursive --check-only --diff || return
+    for dir in /opt/enhydris*; do
+        ( cd $dir && find . -prune -name '*.py' -o -type d | xargs isort --check-only --diff ) || return
+    done
     python /opt/enhydris/manage.py makemigrations --check || return
     python /opt/enhydris/manage.py test enhydris enhydris_openhigis enhydris_synoptic enhydris_autoprocess --failfast
 }

--- a/urls.py
+++ b/urls.py
@@ -2,7 +2,8 @@ from django.conf.urls.static import static
 from django.urls import include, path
 
 from enhydris import urls as enhydris_urls
-from enhydris_openhigis import urls as enhydris_openhigis_urls
+
+from enhydris_openhigis import urls as enhydris_openhigis_urls  # isort:skip
 
 urlpatterns = [
     path("openhigis/", include(enhydris_openhigis_urls)),


### PR DESCRIPTION
isort>=5 does not support the --recursive option (it works recursively
anyway), so it had to be removed. In addition, apparently it searches
from the current directory upwards for .isort.cfg, and not from the
checked file upwards, so we need to change directory in order to check
different working directories.