### PR TITLE
Add support for setting up a MacOS environment (fixes #18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 shared
 !shared/KEEP
 .vagrant/
+.DS_Store
 enhydris
 enhydris-autoprocess
 enhydris-synoptic

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM --platform=linux/amd64 debian:bullseye-slim
 ARG apt_proxy_line=''
 ARG USER_ID=65534
 ARG GROUP_ID=65534
@@ -66,11 +66,9 @@ EXPOSE 8000
 EXPOSE 5901
 
 RUN echo "mycontainer" > /etc/hostname
-RUN echo "127.0.0.1	localhost" > /etc/hosts
-RUN echo "127.0.0.1	mycontainer" >> /etc/hosts
 
-RUN addgroup --gid $GROUP_ID enhydris
-RUN adduser --uid $USER_ID --gid $GROUP_ID --disabled-password --gecos "" enhydris
+RUN groupadd -o --gid $GROUP_ID enhydris
+RUN adduser --uid $USER_ID --gid $GROUP_ID --gecos "" enhydris
 RUN usermod -G sudo enhydris
 RUN sed -i 's/%sudo.*/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Ready-made Enhydris development environment
 
 - On Windows: VirtualBox
 - Linux: Docker
+- Mac: Docker
 
 ## Setting up
 
@@ -46,7 +47,9 @@ Ready-made Enhydris development environment
 8. Once in the container, `dbimport` will import the database.
 
 9. `python manage.py migrate` will ensure the database is up-to-date (the
-   database import file could be slightly out of date).
+   database import file could be slightly out of date). If some of the migrations
+   failed due to existing tables that are already created by the `dbimport` command,
+   `python manage.py migrate --fake-initial` will mark the migrations as applied.
 
 10. In the container, `npm install` will install npm packages needed for
     the tests.

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,10 @@ if docker_image_has_changed; then
         -v `pwd`/enhydris-openhigis:/opt/enhydris-openhigis \
         -v `pwd`/enhydris-synoptic:/opt/enhydris-synoptic \
         -v `pwd`/enhydris-autoprocess:/opt/enhydris-autoprocess \
-        -v `pwd`/shared:/shared -p 15432:5432 -p 8001:80 -p 5901:5901 enhydris-dev
+        -v `pwd`/shared:/shared -p 15432:5432 -p 8001:8000 -p 5901:5901 \
+        --add-host localhost:127.0.0.1 \
+        --add-host mycontainer:127.0.0.1 \
+        enhydris-dev
 else
     echo "Container already exists; starting it..."
     docker start -i enhydris-dev


### PR DESCRIPTION
Fixes #18

Update the `Dockerfile` and the `run.sh` script to work in a Mac OS environment without breaking support to the existing supported operating systems (i.e. Linux & Windows).

The README.md is also updated to address what should be done when running a migration fails due to existing tables that are imported by the `dbimport` command.